### PR TITLE
Emk tweaks round 1

### DIFF
--- a/basics.md
+++ b/basics.md
@@ -49,7 +49,7 @@ Cage draws its terminology from the container ecosystem, including Docker and Ku
 
 * A **source** is where a service's code is found—this could be a pre-built container image or a local source tree.
 
-* A **target** is also known as an "environment," although we avoid that term to reduce confusion with *environment variables*, which Cage actively manages. Common targets include `development` (your laptop), `test` (automated builds on CI services), and `production`.
+* A **target** is also known as an "environment," although we avoid that term to reduce confusion with *environment variables*, which Cage actively manages. Common targets include `development` (your laptop), `test` (for running test suites), and `production`.
 
 * A **pod** is a tightly-linked group of containers that are always deployed together. Kubernetes offers a [more complete definition](http://kubernetes.io/docs/user-guide/pods/). If you're using Amazon's ECS, a pod corresponds to an ECS "task" or "service". If you're using Docker Swarm, a pod corresponds to a single docker-compose.xml file full of services that you always launch as a single unit.
 

--- a/basics.md
+++ b/basics.md
@@ -16,13 +16,13 @@ body_id: basics
 Much like the "Rails way" defined a convention for structuring a standalone web application, Cage offers a uniform format for describing a broad class of multi-service Docker applications.
 
 ```
-myproject/          
+myproject/
 ├── config
-│   └── project.yml 
+│   └── project.yml
 └── pods
-    ├── common.env  
+    ├── common.env
     ├── frontend.yml
-    └── overrides   
+    └── targets
         └── test
             └── common.env
 ```
@@ -35,7 +35,7 @@ myproject/
 
 * The `pods/common.env` file specifies environment variables that are made available to all services in any pod. Each pod can also have its own `pods/podname.yml` file for pod-specific environment variables.
 
-* Finally, the `overrides/` dir contains a subdir for each target that requires special overrides, either to the pod definition or environment variables.
+* Finally, the `targets/` dir contains a subdir for each target that requires special overrides, either to the pod definition or environment variables.
 </section>
 
 <section>

--- a/index.md
+++ b/index.md
@@ -26,11 +26,23 @@ Define your application structure and environment variables in a new Cage repo:
 $ cage new myproject
 $ tree myproject
 myproject/
-├── config
-│   └── project.yml
+├── ...
 └── pods
     ├── common.env
+    ├── frontend.yml
     └── ...
+```
+
+Define how your application works in `frontend.yml`:
+
+``` yaml
+version: "2"
+services:
+  rails_hello:
+    image: "faraday/rails_hello"
+    build: "https://github.com/faradayio/rails_hello.git"
+    ports:
+    - "3000:3000"
 ```
 
 Bring up the whole stack with a single command:
@@ -42,11 +54,12 @@ $ cage up
 Check out a single service for local development and testing:
 
 ``` shell
-$ cage mount frontend
-$ $EDITOR src/frontend
-$ cage test frontend
-# commit and push changes, then . . .
-$ cage unmount frontend
+$ cage source clone rails_hello
+# Restart the app using the cloned source code.
+$ cage up
+$ $EDITOR src/rails_hello
+$ cage test rails_hello
+# Commit and push changes.
 ```
 
 Voilà!

--- a/setup.md
+++ b/setup.md
@@ -137,7 +137,7 @@ $ cage shell web
 You can always check on the status of each of your application's services like so:
 
 ``` shell
-$ cage source list
+$ cage source ls
 rails_hello               https://github.com/faradayio/rails_hello.git
   Cloned at src/rails_hello (mounted)
 ```

--- a/setup.md
+++ b/setup.md
@@ -15,7 +15,7 @@ body_id: setup
 
 The first step is to make sure your application is appropriate for Cage. Does it meet the following criteria?
 
-* Multiple Dockerized services, each with their own repo on GitHub
+* Multiple Dockerized services
 * ...
 
 </section>
@@ -62,7 +62,7 @@ $ tree
     ├── frontend.yml
     ├── migrate.metadata.yml
     ├── migrate.yml
-    └── overrides
+    └── targets
         ├── development
         │   └── common.env
         ├── production
@@ -106,8 +106,8 @@ $ open http://localhost:3000
 What if we want to make changes to one of the application's services, while using pre-built Docker images for everything else? We use the `cage mount` command to "check out" the service's source locally.
 
 ``` shell
-$ cage mount web
-$ $EDITOR src/web
+$ cage clone rails_hello
+$ $EDITOR src/rails_hello
 ```
 
 After we've made some changes, we'll want to run tests:
@@ -137,9 +137,9 @@ $ cage shell web
 You can always check on the status of each of your application's services like so:
 
 ``` shell
-$ cage repo list
+$ cage source list
 rails_hello               https://github.com/faradayio/rails_hello.git
-  Cloned at src/rails_hello
+  Cloned at src/rails_hello (mounted)
 ```
 </section>
 


### PR DESCRIPTION
 I love the site!

What I propose changing in this PR:
- I downplay the `mount` and `unmount` commands in the early examples,
  because they're less important.
- I fix the front page example to work correctly.  But to do so, I need
  to explain the difference between `frontend` and `node_hello`, which
  is easiest to explain if we show a sample `frontend.yml` file.  I'm
  not sure if we want this on the front page, but on the other hand, I'm
  not sure if the example makes sense without it.
- I tentatively rename `override` → `target` everywhere.
- I fix a few other bits of syntax.

I may actually get rid of the `clone` command completely, and make it part of the first time you run `mount`.  That's a brilliant idea.
